### PR TITLE
Emit package declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,7 +51,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
Enables TypeScript declaration output so the published package includes the declaration file referenced by package metadata.

`@adminforth/markdown@1.12.8` publishes `types: "dist/index.d.ts"`, but the tarball currently contains `dist/index.js` and `dist/types.js` without `dist/index.d.ts`. Turning on `declaration` in `tsconfig.json` makes `tsc` emit the referenced declaration file during the existing build.

Verification:
- Clean install of `@adminforth/markdown@1.12.8` confirms `dist/index.js` exists and `dist/index.d.ts` is missing.
- `npm pack @adminforth/markdown@1.12.8 --json --ignore-scripts` confirms the published tarball lacks `package/dist/index.d.ts`.
